### PR TITLE
update travils yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ python:
   - "3.6"
 before_install:
   - export DISPLAY=:99.0
-  - export MPLBACKEND="agg" 
-  - sh -e /etc/init.d/xvfb start
+  - export MPLBACKEND="agg"
+services:
+  - xvfb
 install:
   - sudo apt-get update
   # We do this conditionally because it saves us some downloading if the

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: python
 python:
   - "3.6"
 before_install:
-  - export DISPLAY=:99.0
   - export MPLBACKEND="agg"
+dist: xenial
 services:
   - xvfb
 install:

--- a/environment.yml
+++ b/environment.yml
@@ -8,4 +8,5 @@ dependencies:
     - jupyter==1.0.0
     - docopt
     - nbval==0.9.0
+    - fsspec>=0.4.3
 prefix: /home/nikoleta/anaconda3/envs/game-python


### PR DESCRIPTION
Travis CI released an update to their Xenial build environment, which introduced a new way to start up XVFB for front-end builds.

This fixes the travis failure.